### PR TITLE
툴팁의 위치가 리사이즈나 리포지션 이후 반영되지 않는 현상을 수정합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "invaiz-design-system",
   "productName": "INVAIZ Design System",
   "description": "INVAIZ Design System development project",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "INVAIZ Inc.",
   "license": "MIT",
   "main": "./dist/modules.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
-import Alert from "@components/Alerts/Alert";
+import Tooltip from "@components/Tooltips/Tooltip";
 
 const App = () => {
   return (
     <div>
-      <Alert open title="test" />
+      <Tooltip text="text" isArrow>
+        <textarea />
+      </Tooltip>
     </div>
   );
 };

--- a/src/components/Tooltips/IconTooltip.stories.tsx
+++ b/src/components/Tooltips/IconTooltip.stories.tsx
@@ -1,9 +1,8 @@
-import type { ComponentProps } from "react";
-// types
-
 import { Story } from "@storybook/react";
 
-import IconTooltip from "@components/Tooltips/IconTooltip";
+import IconTooltip, {
+  type IconTooltipProps,
+} from "@components/Tooltips/IconTooltip";
 import Input from "@components/Inputs/Input";
 
 export default {
@@ -11,7 +10,7 @@ export default {
   component: IconTooltip,
 };
 
-const Template: Story<ComponentProps<typeof IconTooltip>> = props => (
+const Template: Story<IconTooltipProps> = props => (
   <IconTooltip {...props}>
     <Input placeholder="툴팁을 위한 인풋입니다." />
   </IconTooltip>

--- a/src/components/Tooltips/IconTooltip.stories.tsx
+++ b/src/components/Tooltips/IconTooltip.stories.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps } from "react";
+// types
+
+import { Story } from "@storybook/react";
+
+import IconTooltip from "@components/Tooltips/IconTooltip";
+import Input from "@components/Inputs/Input";
+
+export default {
+  title: "Components/Tooltips/IconTooltip",
+  component: IconTooltip,
+};
+
+const Template: Story<ComponentProps<typeof IconTooltip>> = props => (
+  <IconTooltip {...props}>
+    <Input placeholder="툴팁을 위한 인풋입니다." />
+  </IconTooltip>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  text: "기본적인 툴팁입니다.",
+  icon: "Add",
+};

--- a/src/components/Tooltips/IconTooltip.tsx
+++ b/src/components/Tooltips/IconTooltip.tsx
@@ -11,7 +11,7 @@ import styled from "@themes/styled";
 import { StyleTooltipText } from "@components/Tooltips/styles/Tooltip.style";
 // styles
 
-interface IconTooltipProps extends TooltipProps {
+export interface IconTooltipProps extends TooltipProps {
   /**
    * 텍스트 및 아이콘 사이즈를 조절합니다.
    */

--- a/src/components/Tooltips/ImageTooltip.stories.tsx
+++ b/src/components/Tooltips/ImageTooltip.stories.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps } from "react";
+// types
+
+import { Story } from "@storybook/react";
+
+import ImageTooltip from "@components/Tooltips/ImageTooltip";
+import Input from "@components/Inputs/Input";
+
+export default {
+  title: "Components/Tooltips/ImageTooltip",
+  component: ImageTooltip,
+};
+
+const Template: Story<ComponentProps<typeof ImageTooltip>> = props => (
+  <ImageTooltip {...props}>
+    <Input placeholder="툴팁을 위한 인풋입니다." />
+  </ImageTooltip>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  imageUrl: "https://cdn.imweb.me/thumbnail/20231211/36694a13b2dff.png",
+};

--- a/src/components/Tooltips/ImageTooltip.stories.tsx
+++ b/src/components/Tooltips/ImageTooltip.stories.tsx
@@ -1,9 +1,8 @@
-import type { ComponentProps } from "react";
-// types
-
 import { Story } from "@storybook/react";
 
-import ImageTooltip from "@components/Tooltips/ImageTooltip";
+import ImageTooltip, {
+  type ImageTooltipProps,
+} from "@components/Tooltips/ImageTooltip";
 import Input from "@components/Inputs/Input";
 
 export default {
@@ -11,7 +10,7 @@ export default {
   component: ImageTooltip,
 };
 
-const Template: Story<ComponentProps<typeof ImageTooltip>> = props => (
+const Template: Story<ImageTooltipProps> = props => (
   <ImageTooltip {...props}>
     <Input placeholder="툴팁을 위한 인풋입니다." />
   </ImageTooltip>

--- a/src/components/Tooltips/ImageTooltip.tsx
+++ b/src/components/Tooltips/ImageTooltip.tsx
@@ -8,7 +8,7 @@ import TooltipBase from "@components/Tooltips/TooltipBase";
 import { StyleTooltipText } from "@components/Tooltips/styles/Tooltip.style";
 // styles
 
-interface HaveImageTooltipProps extends TooltipProps {
+export interface ImageTooltipProps extends TooltipProps {
   /**
    * 툴팁과 함께 보여질 이미지의 경로(이름)입니다.
    */
@@ -25,7 +25,7 @@ const ImageTooltip = ({
   isArrow,
   imageUrl,
   children,
-}: HaveImageTooltipProps) => (
+}: ImageTooltipProps) => (
   <TooltipBase
     contents={
       <StyleTooltipText textSize={textSize}>

--- a/src/components/Tooltips/Tooltip.stories.tsx
+++ b/src/components/Tooltips/Tooltip.stories.tsx
@@ -1,0 +1,29 @@
+import type { TooltipProps } from "@components/Tooltips/interfaces/Tooltip.interface";
+// types
+
+import { Story } from "@storybook/react";
+
+import Tooltip from "@components/Tooltips/Tooltip";
+import Input from "@components/Inputs/Input";
+
+export default {
+  title: "Components/Tooltips/Tooltip",
+  component: Tooltip,
+};
+
+const Template: Story<TooltipProps> = props => (
+  <Tooltip {...props}>
+    <Input placeholder="툴팁을 위한 인풋입니다." />
+  </Tooltip>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  text: "기본적인 툴팁입니다.",
+};
+
+export const Arrow = Template.bind({});
+Arrow.args = {
+  text: "화살표가 있는 툴팁입니다.",
+  isArrow: true,
+};

--- a/src/components/Tooltips/TooltipBase.stories.tsx
+++ b/src/components/Tooltips/TooltipBase.stories.tsx
@@ -1,7 +1,8 @@
-import type { ComponentProps } from "react";
-
 import { Story } from "@storybook/react";
-import TooltipBase from "@components/Tooltips/TooltipBase";
+
+import TooltipBase, {
+  type TooltipBaseProps,
+} from "@components/Tooltips/TooltipBase";
 import Input from "@components/Inputs/Input";
 
 export default {
@@ -9,7 +10,7 @@ export default {
   component: TooltipBase,
 };
 
-const Template: Story<ComponentProps<typeof TooltipBase>> = props => (
+const Template: Story<TooltipBaseProps> = props => (
   <TooltipBase {...props}>
     <Input placeholder="툴팁을 위한 인풋입니다." />
   </TooltipBase>

--- a/src/components/Tooltips/TooltipBase.stories.tsx
+++ b/src/components/Tooltips/TooltipBase.stories.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps } from "react";
+
+import { Story } from "@storybook/react";
+import TooltipBase from "@components/Tooltips/TooltipBase";
+import Input from "@components/Inputs/Input";
+
+export default {
+  title: "Components/Tooltips/TooltipBase",
+  component: TooltipBase,
+};
+
+const Template: Story<ComponentProps<typeof TooltipBase>> = props => (
+  <TooltipBase {...props}>
+    <Input placeholder="툴팁을 위한 인풋입니다." />
+  </TooltipBase>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  contents: (
+    <div>
+      <p>두 줄로 적기</p>
+      <p style={{ color: "red" }}>가능합니다.</p>
+    </div>
+  ),
+};

--- a/src/components/Tooltips/TooltipBase.tsx
+++ b/src/components/Tooltips/TooltipBase.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useState, useEffect, cloneElement } from "react";
+import {
+  type ReactNode,
+  useState,
+  useEffect,
+  cloneElement,
+  useCallback,
+} from "react";
 import { createPortal } from "react-dom";
 // React modules
 
@@ -34,18 +40,7 @@ const TooltipBase = ({
     y: 0,
   });
 
-  useEffect(() => {
-    const onMouseOver = () => {
-      setVisible(() => true);
-    };
-
-    const onMouseLeave = () => {
-      setVisible(() => false);
-    };
-
-    childrenRef?.addEventListener("mouseover", onMouseOver);
-    childrenRef?.addEventListener("mouseleave", onMouseLeave);
-
+  const calculatePosition = useCallback(() => {
     if (childrenRef) {
       const { x, y, width, height } = childrenRef.getBoundingClientRect();
       setPoint({
@@ -57,12 +52,38 @@ const TooltipBase = ({
           (isArrow ? HAVE_ARROW_ADDITIONAL_SPACE : 0),
       });
     }
+  }, [childrenRef, isArrow]);
+
+  useEffect(() => {
+    calculatePosition();
+  }, [visible, calculatePosition]);
+
+  useEffect(() => {
+    const onMouseOver = () => {
+      setVisible(() => true);
+    };
+
+    const onMouseLeave = () => {
+      setVisible(() => false);
+    };
+
+    const resizeObserver = new ResizeObserver(entries => {
+      calculatePosition();
+    });
+
+    if (childrenRef !== null) {
+      resizeObserver.observe(childrenRef);
+    }
+
+    childrenRef?.addEventListener("mouseover", onMouseOver);
+    childrenRef?.addEventListener("mouseleave", onMouseLeave);
 
     return () => {
       childrenRef?.removeEventListener("mouseover", onMouseOver);
       childrenRef?.removeEventListener("mouseleave", onMouseLeave);
+      resizeObserver.disconnect();
     };
-  }, [childrenRef, isArrow]);
+  }, [childrenRef, calculatePosition]);
 
   return (
     <>

--- a/src/components/Tooltips/TooltipBase.tsx
+++ b/src/components/Tooltips/TooltipBase.tsx
@@ -19,7 +19,7 @@ const BETWEEN_CONTENTS_SPACE = 10 as const;
 const HAVE_ARROW_ADDITIONAL_SPACE = 7 as const;
 // constants
 
-interface TooltipBaseProps extends TooltipCommonProps {
+export interface TooltipBaseProps extends TooltipCommonProps {
   contents: ReactNode;
 }
 

--- a/src/modules.tsx
+++ b/src/modules.tsx
@@ -30,6 +30,7 @@ export { default as Toggle } from "@components/Toggles/Toggle";
 export { default as TabLine } from "@components/Tabs/TabLine";
 export { default as TabPanel } from "@components/Tabs/TabPanel";
 
+export { default as TooltipBase } from "@components/Tooltips/TooltipBase";
 export { default as Tooltip } from "@components/Tooltips/Tooltip";
 export { default as IconTooltip } from "@components/Tooltips/IconTooltip";
 export { default as ImageTooltip } from "@components/Tooltips/ImageTooltip";


### PR DESCRIPTION
## 개요 🔍

- 툴팁이 적용된 요소 위치가 변경됐을 때, 툴팁의 위치가 비정상적인 것을 수정합니다.

## 작업 내용 📝

- 리렌더링 타이밍에 위치를 계산하게 하면서, `ResizeObserver`를 적용합니다.

## 기타 사항 🙋‍♂️

- 툴팁에 대한 스토리북 작성과, `TooltipBase`를 함께 내보내도록 합니다.