### PR TITLE
Tooptip의 `z-index`를 설정할 수 있도록 합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "invaiz-design-system",
   "productName": "INVAIZ Design System",
   "description": "INVAIZ Design System development project",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "INVAIZ Inc.",
   "license": "MIT",
   "main": "./dist/modules.mjs",

--- a/src/components/Tooltips/IconTooltip.tsx
+++ b/src/components/Tooltips/IconTooltip.tsx
@@ -28,6 +28,7 @@ export interface IconTooltipProps extends TooltipProps {
 const IconTooltip = ({
   text,
   textSize = 16,
+  zIndex,
   borderRadiusRatio,
   isArrow,
   icon,
@@ -40,6 +41,7 @@ const IconTooltip = ({
         <StyleText>{text}</StyleText>
       </StyleTooltipText>
     }
+    zIndex={zIndex}
     borderRadiusRatio={borderRadiusRatio}
     isArrow={isArrow}
   >

--- a/src/components/Tooltips/ImageTooltip.tsx
+++ b/src/components/Tooltips/ImageTooltip.tsx
@@ -21,6 +21,7 @@ export interface ImageTooltipProps extends TooltipProps {
 const ImageTooltip = ({
   text,
   textSize,
+  zIndex,
   borderRadiusRatio,
   isArrow,
   imageUrl,
@@ -33,6 +34,7 @@ const ImageTooltip = ({
         {text}
       </StyleTooltipText>
     }
+    zIndex={zIndex}
     borderRadiusRatio={borderRadiusRatio}
     isArrow={isArrow}
   >

--- a/src/components/Tooltips/Popper.tsx
+++ b/src/components/Tooltips/Popper.tsx
@@ -19,13 +19,14 @@ const OUTLINE_PIXEL = 10 as const;
 
 type PopperBaseProps = Required<Pick<TooltipCommonProps, "borderRadiusRatio">>;
 type PopperProps = PropsWithChildren<
-  PopperBaseProps & Pick<TooltipCommonProps, "isArrow"> & Point
+  PopperBaseProps & Pick<TooltipCommonProps, "zIndex" | "isArrow"> & Point
 >;
 // types
 
 const Popper = ({
   x,
   y,
+  zIndex,
   borderRadiusRatio,
   isArrow,
   children,
@@ -67,7 +68,15 @@ const Popper = ({
   }, [popperRef]);
 
   return (
-    <StylePopperWrapper ref={setPopperRef} role="tooltip" x={x} y={y}>
+    <StylePopperWrapper
+      ref={setPopperRef}
+      style={{
+        zIndex: zIndex,
+      }}
+      role="tooltip"
+      x={x}
+      y={y}
+    >
       <StylePopper {...delta} borderRadiusRatio={borderRadiusRatio}>
         {children}
       </StylePopper>

--- a/src/components/Tooltips/Tooltip.tsx
+++ b/src/components/Tooltips/Tooltip.tsx
@@ -13,12 +13,14 @@ import { StyleTooltipText } from "@components/Tooltips/styles/Tooltip.style";
 const Tooltip = ({
   text,
   textSize,
+  zIndex,
   borderRadiusRatio,
   isArrow,
   children,
 }: TooltipProps) => (
   <TooltipBase
     contents={<StyleTooltipText textSize={textSize}>{text}</StyleTooltipText>}
+    zIndex={zIndex}
     borderRadiusRatio={borderRadiusRatio}
     isArrow={isArrow}
   >

--- a/src/components/Tooltips/TooltipBase.tsx
+++ b/src/components/Tooltips/TooltipBase.tsx
@@ -28,6 +28,7 @@ export interface TooltipBaseProps extends TooltipCommonProps {
  */
 const TooltipBase = ({
   contents,
+  zIndex = 1000,
   borderRadiusRatio = 2,
   isArrow,
   children,
@@ -91,6 +92,7 @@ const TooltipBase = ({
         createPortal(
           <Popper
             {...point}
+            zIndex={zIndex}
             borderRadiusRatio={borderRadiusRatio}
             isArrow={isArrow}
           >

--- a/src/components/Tooltips/__tests__/Tooltip.test.tsx
+++ b/src/components/Tooltips/__tests__/Tooltip.test.tsx
@@ -49,4 +49,34 @@ describe("Tooltip", () => {
 
     expect(renderTooltip).not.toBeInTheDocument();
   });
+
+  it("툴팁의 `z-index` 기본값은 `1,000`이다.", async () => {
+    const { getByRole } = render(
+      <Tooltip text={TOOLTIP_TEXT} zIndex={1500}>
+        <button type="button">{BUTTON_CONTENT}</button>
+      </Tooltip>
+    );
+    const button = getByRole("button");
+
+    fireEvent.mouseOver(button);
+
+    const renderTooltip = getByRole("tooltip");
+    expect(renderTooltip).toBeInTheDocument();
+    expect(renderTooltip).toHaveStyle("z-index: 1500");
+  });
+
+  it("툴팁의 `z-index`는 설정할 수 있다.", async () => {
+    const { getByRole } = render(
+      <Tooltip text={TOOLTIP_TEXT} zIndex={1500}>
+        <button type="button">{BUTTON_CONTENT}</button>
+      </Tooltip>
+    );
+    const button = getByRole("button");
+
+    fireEvent.mouseOver(button);
+
+    const renderTooltip = getByRole("tooltip");
+    expect(renderTooltip).toBeInTheDocument();
+    expect(renderTooltip).toHaveStyle("z-index: 1500");
+  });
 });

--- a/src/components/Tooltips/__tests__/Tooltip.test.tsx
+++ b/src/components/Tooltips/__tests__/Tooltip.test.tsx
@@ -52,7 +52,7 @@ describe("Tooltip", () => {
 
   it("툴팁의 `z-index` 기본값은 `1,000`이다.", async () => {
     const { getByRole } = render(
-      <Tooltip text={TOOLTIP_TEXT} zIndex={1500}>
+      <Tooltip text={TOOLTIP_TEXT}>
         <button type="button">{BUTTON_CONTENT}</button>
       </Tooltip>
     );
@@ -62,7 +62,7 @@ describe("Tooltip", () => {
 
     const renderTooltip = getByRole("tooltip");
     expect(renderTooltip).toBeInTheDocument();
-    expect(renderTooltip).toHaveStyle("z-index: 1500");
+    expect(renderTooltip).toHaveStyle("z-index: 1000");
   });
 
   it("툴팁의 `z-index`는 설정할 수 있다.", async () => {

--- a/src/components/Tooltips/interfaces/Tooltip.interface.ts
+++ b/src/components/Tooltips/interfaces/Tooltip.interface.ts
@@ -3,6 +3,12 @@ import type { ReactElement } from "react";
 
 export interface TooltipCommonProps {
   /**
+   * 툴팁의 `z-index` 높이를 조절합니다.
+   *
+   * * 기본값은 `1000`입니다.
+   */
+  zIndex?: number;
+  /**
    * 모서리 라운드 값을 조정합니다.
    *
    * * 5의 배수로 적용됩니다.


### PR DESCRIPTION
## 개요 🔍

- `Tooltip` 컴포넌트에서 `z-index`를 설정할 수 있도록 합니다.

## 작업 내용 📝

`z-index` `props`를 추가하고 이를 3개의 툴팁 컴포넌트에 모두 적용하였습니다.
테스트를 작성하여 잘 적용되는지 확인합니다.

## 기타 사항 🙋‍♂️

`IconTooltip`, `ImageTooltip`에는 테스트를 적용하지 않았습니다.
`style` 요소를 넘겨주는 것이 아니라, `z-index`를 넘겨주도록 하였습니다.