### PR TITLE
`Tooltip`의 화살표를 표시하는 선택자 방식을 변경하고, 기본 텍스트 컬러를 반영합니다.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,11 +5,7 @@
     "es6": true,
     "jest": true
   },
-  "extends": [
-    "react-app",
-    "prettier",
-    "eslint:recommended"
-  ],
+  "extends": ["react-app", "prettier", "eslint:recommended"],
   "plugins": ["react", "@typescript-eslint", "prettier", "jest"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -24,7 +20,10 @@
     "@typescript-eslint/no-unused-vars": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
-    "react/jsx-filename-extension": ["error", { "extensions": [".ts", ".tsx"] }],
+    "react/jsx-filename-extension": [
+      "error",
+      { "extensions": [".ts", ".tsx"] }
+    ],
     "react/function-component-definition": ["off"],
     "react/prop-types": "off",
     "react/require-default-props": "off",
@@ -35,7 +34,7 @@
     "no-unused-vars": "warn",
     "no-undef": "off",
     "no-case-declarations": "off",
-    "no-console": ["warn", { "allow": ["error", "info"] }],
+    "no-console": ["warn", { "allow": ["error", "warn"] }],
     "spaced-comment": "error",
     "camelcase": "error"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "invaiz-design-system",
   "productName": "INVAIZ Design System",
   "description": "INVAIZ Design System development project",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": "INVAIZ Inc.",
   "license": "MIT",
   "main": "./dist/modules.mjs",

--- a/src/components/Tooltips/styles/Tooltip.style.ts
+++ b/src/components/Tooltips/styles/Tooltip.style.ts
@@ -4,16 +4,16 @@ import type { TextTooltipProps } from "@components/Tooltips/TextTooltip";
 import styled, { css } from "@themes/styled";
 // styles
 
-// eslint-disable-next-line import/prefer-default-export
 export const StyleTooltipText = styled.p<Pick<TextTooltipProps, "textSize">>`
-  color: #fff;
   ${({ theme }) => theme.font.kopub.contents5}
+
+  line-height: 1.2;
 
   ${({ textSize }) =>
     textSize &&
     css`
       font-size: ${textSize}px;
     `}
-  
+
   margin: 0;
 `;


### PR DESCRIPTION
## 작업 내용 📝

- `ESLint`로 `no-console`의 허용 함수를 `info` -> `warn`로 변경하고, `Tooltip`의 크기가 화면을 초과할 때 `console.warn`으로 메시지를 표시합니다.
- `Tooltip`의 크기가 화면의 크기를 넘었을 때, 방향을 변경하는 로직을 실행하지 않습니다.
- `TextTooltip`의 기본 행간을 조정하고, 모든 `Tooltip`의 초기 텍스트 색상이 디자인 테마를 따르도록 합니다.
