### PR TITLE
툴팁에 마우스 이벤트가 불가하도록 하고, 자식 요소의 상태 변경 시 포지션을 다시 계산합니다.

### DIFF
--- a/src/components/Tooltips/Popper.tsx
+++ b/src/components/Tooltips/Popper.tsx
@@ -151,11 +151,20 @@ const Popper = ({
       rootMargin: `${OUTLINE_PIXEL}px`,
     });
     const resizeObserver = new ResizeObserver(reposition);
+    const mutationObserver = new MutationObserver(reposition);
+    if (baseRef) {
+      mutationObserver.observe(baseRef, {
+        attributes: true,
+      });
+    }
     if (popperRef) {
       resizeObserver.observe(popperRef);
-      intersectionObserver.observe(popperRef);
     }
+
     return () => {
+      if (baseRef) {
+        mutationObserver.disconnect();
+      }
       if (popperRef) {
         resizeObserver.unobserve(popperRef);
         intersectionObserver.unobserve(popperRef);
@@ -201,6 +210,8 @@ const Wrapper = styled.div`
   inset: 0 auto auto 0;
 
   visibility: hidden;
+
+  pointer-events: none;
 `;
 
 const ContentBox = styled.div<PopperBaseProps>`


### PR DESCRIPTION
## 작업 내용 📝

- 툴팁에 마우스 상호작용을 없앱니다.
- 툴팁 자식 요소의 `attributes`가 변경될 경우 위치계산을 다시하도록 `MutationObserver`를 정의합니다.

## 기타 사항 🙋‍♂️

- 자식 요소의 위치 변경 시 처리는 지원되지 않습니다.